### PR TITLE
Updated vulnerable `NuGet.*` packages to `6.14.3`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,7 @@ See https://learn.microsoft.com/en-us/visualstudio/msbuild/customize-by-director
   </PropertyGroup>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,8 +19,11 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.6.2" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.6.2" />
-    <PackageVersion Include="NuGet.Common" Version="6.11.1" />
-    <PackageVersion Include="NuGet.Protocol" Version="6.11.1" />
+    <PackageVersion Include="NuGet.Common" Version="6.14.3" />
+    <PackageVersion Include="NuGet.Protocol" Version="6.14.3" />
+    <PackageVersion Include="NuGet.Packaging" Version="6.14.3" />
+    <PackageVersion Include="System.Drawing.Common" Version="8.0.27" />
+    <PackageVersion Include="System.Formats.Asn1" Version="8.0.2" />
     <PackageVersion Include="Octokit" Version="13.0.1" />
     <PackageVersion Include="R3" Version="1.2.9" />
     <PackageVersion Include="Unquote" Version="7.0.0" />


### PR DESCRIPTION
## Proposed Changes

Enables Central Package Transitive Pinning (`CentralPackageTransitivePinningEnabled`) in `Directory.Build.props` so that all transitive NuGet dependencies are resolved exclusively from the versions declared in `Directory.Packages.props`. As a direct consequence, several vulnerable or outdated transitive packages are pinned explicitly: `NuGet.Common` and `NuGet.Protocol` are upgraded from `6.11.1` to `6.14.3`, and `NuGet.Packaging`, `System.Drawing.Common`, and `System.Formats.Asn1` are added as explicit version pins to satisfy security advisories. The SDK is updated to `10.0.300` and the legacy `.sln` file is replaced by the newer `.slnx` format. All GitHub Actions workflows are updated to their latest action versions.

## Types of changes

What types of changes does your code introduce to FSharp.Control.R3?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate) – not applicable; this is a dependency/tooling update with no logic changes
- [ ] I have added necessary documentation (if appropriate) – not applicable; no public API changes

## Further comments

Transitive pinning is enforced by adding `<CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>` to `Directory.Build.props`. This requires that any transitive package whose resolved version must be overridden is listed explicitly in `Directory.Packages.props` – hence the addition of `NuGet.Packaging`, `System.Drawing.Common`, and `System.Formats.Asn1` entries. Without these pins the build would fail under the new pinning policy.