### PR TITLE
ci(ai): add Copilot setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,43 @@
+name: "Copilot Setup Steps"
+
+# Automatically run the setup steps when they are changed to allow for easy validation, and
+# allow manual testing through the repository's "Actions" tab
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    # Set the permissions to the lowest permissions possible needed for your steps.
+    # Copilot will be given its own token for its operations.
+    permissions:
+      # If you want to clone the repository as part of your setup steps, for example to install dependencies, you'll need the `contents: read` permission. If you don't clone the repository in your setup steps, Copilot will do this for you automatically after the steps complete.
+      contents: read
+
+    # You can define any steps you want, and they will run before the agent starts.
+    # If you do not check out your code, Copilot will do this for you.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup necessary dotnet SDKs
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+          dotnet-version: |
+            8.x
+            9.x
+            10.x
+
+      - name: Restore dependencies
+        run: |
+          dotnet tool restore
+          dotnet restore FSharp.Control.R3.slnx


### PR DESCRIPTION
## Proposed Changes

Added a new GitHub Actions workflow at `.github/workflows/copilot-setup-steps.yml` to provide setup steps for Copilot agent runs. The workflow is triggered by manual dispatch, pushes that modify this workflow file, and pull requests that modify the same path. It defines a required `copilot-setup-steps` job on `ubuntu-latest` with minimal `contents: read` permissions. The job checks out the repository, installs .NET SDKs based on `global.json` plus versions 8.x, 9.x, and 10.x, then restores tools and solution dependencies using `dotnet tool restore` and `dotnet restore FSharp.Control.R3.slnx`.

## Types of changes

What types of changes does your code introduce to FSharp.Control.R3?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Build and tests pass locally (not evidenced in diff/commits)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)